### PR TITLE
remove the git clone install

### DIFF
--- a/docs/02installation/01helm-chart.md
+++ b/docs/02installation/01helm-chart.md
@@ -14,13 +14,6 @@ This functionality is in alpha and is subject to change. The code is provided as
 
 [Helm](https://helm.sh/) must be installed to use the charts. Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
 
-```bash
-$ git clone https://github.com/hwameistor/helm-charts.git 
-$ cd helm-charts/charts 
-$ helm install hwameistor -n hwameistor --create-namespace --generate-name
-```
-
-Or
 
 ```bash
 $ helm repo add hwameistor http://hwameistor.io/helm-charts 

--- a/i18n/cn/docusaurus-plugin-content-docs/current/02installation/01helm-chart.md
+++ b/i18n/cn/docusaurus-plugin-content-docs/current/02installation/01helm-chart.md
@@ -15,14 +15,6 @@ sidebar_position: 2
 必须先安装 [Helm](https://helm.sh/) 才能使用 chart，请参阅 Helm [官方文档](https://helm.sh/docs/)。
 
 ```bash
-$ git clone https://github.com/hwameistor/helm-charts.git 
-$ cd helm-charts/charts 
-$ helm install hwameistor -n hwameistor --create-namespace --generate-name
-```
-
-或
-
-```bash
 $ helm repo add hwameistor http://hwameistor.io/helm-charts 
 $ helm install hwameistor/hwameistor -n hwameistor --create-namespace --generate-name
 ```


### PR DESCRIPTION
Using git clone to install is not offical.

Should we delete it. 